### PR TITLE
int2f: Allow 1217h function to return new CDS

### DIFF
--- a/kernel/dosfns.c
+++ b/kernel/dosfns.c
@@ -46,6 +46,13 @@ STATIC int remote_lock_unlock(sft FAR *sftp,    /* SFT for file */
                              unsigned long len, /* length (in bytes) of region to lock or unlock */
                              int unlock);       /* one to unlock; zero to lock */
 
+struct cds FAR *get_cds_unvalidated(unsigned drive)
+{
+  if (drive >= lastdrive)
+    return NULL;
+  return &CDSp[drive];
+}
+
 /* get current directory structure for drive
    return NULL if the CDS is not valid or the
    drive is not within range */

--- a/kernel/inthndlr.c
+++ b/kernel/inthndlr.c
@@ -1895,7 +1895,7 @@ VOID ASMCFUNC int2F_12_handler(struct int2f12regs r)
                                    ; probable use: get sizeof(CDSentry)
                                  */
       {
-        struct cds FAR *cdsp = get_cds(r.callerARG1 & 0xff);
+        struct cds FAR *cdsp = get_cds_unvalidated(r.callerARG1 & 0xff);
 
         if (cdsp == NULL)
         {

--- a/kernel/proto.h
+++ b/kernel/proto.h
@@ -118,6 +118,7 @@ COUNT DosLockUnlock(COUNT hndl, LONG pos, LONG len, COUNT unlock);
 int idx_to_sft_(int SftIndex);
 __FAR(sft)idx_to_sft(int SftIndex);
 int get_sft_idx(UCOUNT hndl);
+__FAR(struct cds)get_cds_unvalidated(unsigned dsk);
 __FAR(struct cds)get_cds(unsigned dsk);
 __FAR(struct cds)get_cds1(unsigned dsk);
 COUNT DosTruename(__FAR(const char) src,__FAR(char) dest);


### PR DESCRIPTION
When a redirector calls int2f/1217h to get a CDS for creation of a
new drive, the cds_flags were being checked for validity. This
meant that only the CDS for drives that had previously been
initialised could be redirected (without manipulating CDS array
directly). This is not the behaviour of other DOS variants which
allow the return of the requested CDS regardless.

#### Prior tests of the int2f/1217h function to return a new drive's CDS show
~~~
Test DR-DOS-6.00-930319 MFS lredir2 command redirection ... ok
Test DR-DOS-7.00 MFS lredir2 command redirection ... ok
Test DR-DOS-7.01 MFS lredir2 command redirection ... ok
Test DR-DOS-7.02-971119 MFS lredir2 command redirection ... ok
Test DR-DOS-7.02-980123 MFS lredir2 command redirection ... ok
Test DR-DOS-7.03 MFS lredir2 command redirection ... ok
Test DR-DOS-8.00 MFS lredir2 command redirection ... ok
Test FR-DOS-1.00 MFS lredir2 command redirection ... FAIL
Test FR-DOS-1.10 MFS lredir2 command redirection ... FAIL
Test FR-DOS-1.20 MFS lredir2 command redirection ... FAIL
Test MS-DOS-3.10 MFS lredir2 command redirection ... ok
Test MS-DOS-3.20 MFS lredir2 command redirection ... ok
Test MS-DOS-3.21 MFS lredir2 command redirection ... ok
Test MS-DOS-3.30-Nec MFS lredir2 command redirection ... ok
Test MS-DOS-3.30 MFS lredir2 command redirection ... ok
Test MS-DOS-3.31 MFS lredir2 command redirection ... ok
Test MS-DOS-4.01 MFS lredir2 command redirection ... ok
Test MS-DOS-5.00 MFS lredir2 command redirection ... ok
Test MS-DOS-6.00 MFS lredir2 command redirection ... ok
Test MS-DOS-6.20 MFS lredir2 command redirection ... ok
Test MS-DOS-6.21 MFS lredir2 command redirection ... ok
Test MS-DOS-6.22 MFS lredir2 command redirection ... ok
Test MS-DOS-7.00 MFS lredir2 command redirection ... ok
Test MS-DOS-7.10 MFS lredir2 command redirection ... ok
Test PC-DOS-3.00-Compaq MFS lredir2 command redirection ... ok
Test PC-DOS-3.00 MFS lredir2 command redirection ... ok
Test PC-DOS-3.10-850307 MFS lredir2 command redirection ... ok
Test PC-DOS-3.10-850422 MFS lredir2 command redirection ... ok
Test PC-DOS-3.10-Compaq MFS lredir2 command redirection ... ok
Test PC-DOS-3.20-851230 MFS lredir2 command redirection ... ok
Test PC-DOS-3.20-860221 MFS lredir2 command redirection ... ok
Test PC-DOS-3.30 MFS lredir2 command redirection ... ok
Test PC-DOS-3.31-Compaq MFS lredir2 command redirection ... ok
Test PC-DOS-4.00 MFS lredir2 command redirection ... ok
Test PC-DOS-4.01 MFS lredir2 command redirection ... ok
Test PC-DOS-5.00 MFS lredir2 command redirection ... ok
Test PC-DOS-5.02 MFS lredir2 command redirection ... ok
Test PC-DOS-6.10 MFS lredir2 command redirection ... ok
Test PC-DOS-6.30 MFS lredir2 command redirection ... ok
Test PC-DOS-7.00 MFS lredir2 command redirection ... ok
Test PC-DOS-7.10 MFS lredir2 command redirection ... ok
Test PC-DOS-7.2K MFS lredir2 command redirection ... ok
~~~

This patch introduces an unvalidated version of get_cds() and calls
it only for the int2f/1217h call, other uses remain as before.
 
#### Post patch tests for FDPP show
~~~
Test PP-DOS-1.00 MFS lredir2 command redirection ... ok
~~~

Note that these tests were run on Dosemu2 with the FreeDOS workaround
disabled as below:
```C
diff --git a/src/dosext/mfs/mfs.c b/src/dosext/mfs/mfs.c
index 903c520c3..b1c2ce3b3 100644
--- a/src/dosext/mfs/mfs.c
+++ b/src/dosext/mfs/mfs.c
@@ -395,6 +395,8 @@ static int GetCDSInDOS(uint8_t dosdrive, cds_t *cds)

   Debug0((dbg_fd, "GetCDSInDOS for %c:\n", dletter));

+  return _GetCDSInDOS(dosdrive, cds);
+
   if (_GetCDSInDOS(dosdrive, cds))
     return 1;
```