### PR TITLE
api: Add support for kernel symbol handling

### DIFF
--- a/fdpp/fdpp.spec.in
+++ b/fdpp/fdpp.spec.in
@@ -45,5 +45,6 @@ make DESTDIR=%{buildroot} PREFIX=%{_prefix} LIBDIR=%{_libdir} install
 %{_includedir}/fdpp/thunks.h
 %{_includedir}/fdpp/bprm.h
 %{_datadir}/fdpp/fdppkrnl.sys
+%{_datadir}/fdpp/fdppkrnl.map
 
 %changelog

--- a/fdpp/makefile
+++ b/fdpp/makefile
@@ -23,7 +23,7 @@ GIT_REV := $(shell $(srcdir)/git-rev.sh)
 .LOW_RESOLUTION_TIME: $(GIT_REV)
 
 CPPFLAGS += -I . -I $(SRC) -I $(srcdir) -DDATADIR=$(DATADIR) \
-    -DKRNL_NAME=$(TARGET).sys \
+    -DKRNL_NAME=$(TARGET).sys -DKRNL_MAP_NAME=$(TARGET).map \
     -DKERNEL_VERSION="$(VERSION) [GIT: `git describe`]"
 NASMFLAGS += -i$(SRC)
 
@@ -50,7 +50,7 @@ ALL = $(FDPPLIB) $(TARGET).sys $(GEN_EXT)
 all: $(ALL)
 
 $(TARGET).sys: $(srcdir)/kernel.ld $(OBJS) $(PPOBJS) $(DOBJS)
-	$(LINK) -melf_i386 -static -Map kernel.map -o $@ $(^:%.ld=-T%.ld)
+	$(LINK) -melf_i386 -static -Map $(TARGET).map -o $@ $(^:%.ld=-T%.ld)
 	chmod -x $@
 
 clean:
@@ -210,6 +210,7 @@ install: $(FDPPLIB) $(GEN_EXT)
 	install -D -t $(DESTDIR)$(PREFIX)/include/fdpp -m 0644 thunks.h
 	install -D -t $(DESTDIR)$(PREFIX)/include/fdpp -m 0644 bprm.h
 	install -D -t $(DESTDIR)$(DATADIR) -m 0644 fdppkrnl.sys
+	install -D -t $(DESTDIR)$(DATADIR) -m 0644 fdppkrnl.map
 
 $(TGZ): fdpp.spec
 	cd $(srcdir)/.. && git archive -o $(CURDIR)/$(TAR) --prefix=$(PKG)/ HEAD

--- a/fdpp/thunks.cc
+++ b/fdpp/thunks.cc
@@ -712,6 +712,9 @@ void RelocHook(UWORD old_seg, UWORD new_seg, UWORD offs, UDWORD len)
             reloc++;
         }
     }
+    if (fdpp->relocate_notify)
+        fdpp->relocate_notify(old_seg, new_seg, offs, len);
+
     fdlogprintf("processed %i relocs (%i missed)\n", reloc, miss);
 }
 
@@ -755,4 +758,9 @@ const char *FdppKernelName(void)
 const char *FdppVersionString(void)
 {
     return KERNEL_VERSION_STRING;
+}
+
+const char *FdppKernelMapName(void)
+{
+    return _S(KRNL_MAP_NAME);
 }

--- a/fdpp/thunks.h
+++ b/fdpp/thunks.h
@@ -22,7 +22,7 @@
 #include <stdint.h>
 #include <stdarg.h>
 
-#define FDPP_API_VER 17
+#define FDPP_API_VER 18
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,12 +47,15 @@ struct fdpp_api {
         uint16_t off, uint8_t *sp, uint8_t len);
     void (*asm_call_noret)(struct vm86_regs *regs, uint16_t seg,
         uint16_t off, uint8_t *sp, uint8_t len);
+    void (*relocate_notify)(uint16_t oldseg, uint16_t newseg,
+        uint16_t startoff, uint32_t blklen);
 };
 int FdppInit(struct fdpp_api *api, int ver, int *req_ver);
 
 const char *FdppDataDir(void);
 const char *FdppKernelName(void);
 const char *FdppVersionString(void);
+const char *FdppKernelMapName(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
1/ Add the ability to return the kernel map file name

2/ By adding a relocation notification function in the API a
previously loaded set of symbols may be moved as the memory is
relocated.

3/ Install the kernel map file alongside the kernel itself.