### PR TITLE
config: Don't lose driver command line [fixes #85]

### DIFF
--- a/kernel/config.c
+++ b/kernel/config.c
@@ -1966,6 +1966,7 @@ STATIC BOOL LoadDevice(char * pLine, char FAR *top, COUNT mode)
     return result;
   }
 
+  strcpy(szBuf, pLine);
   /* uppercase the device driver command */
   _strupr(szBuf);
 


### PR DESCRIPTION
Command line arguments were lost in commit ab57fb0, this patch restores
them.