### PR TITLE
inthndlr.c: in Int21.43FF, dispatch DosMkRmdir on CL not AH

### DIFF
--- a/kernel/inthndlr.c
+++ b/kernel/inthndlr.c
@@ -968,7 +968,7 @@ dispatch:
                 case 0x39:
                 /* Dos Remove Directory                                         */
                 case 0x3a:
-                rc = DosMkRmdir(FP_DS_DX, lr.AH);
+                rc = DosMkRmdir(FP_DS_DX, lr.CL);
                 goto short_check;
 
                 /* Dos rename file */


### PR DESCRIPTION
As per discussion in https://github.com/PerditionC/fdkernel/pull/33#issuecomment-552095063 here's ecm's fix