### PR TITLE
Travis: Move package add to config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,22 @@ language: c
 
 dist:  bionic
 
+addons:
+  apt:
+    packages:
+      - clang
+      - nasm
+      - libstdc++-5-dev
+      - git
+      - bash
+      - autoconf
+      - flex
+      - bison
+      - sed
+    update: true
+
 before_install:
-  - ./travis_prereq.sh
+  - echo "before_install"
 
 install:
   - ./travis_build.sh

--- a/travis_prereq.sh
+++ b/travis_prereq.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-sudo apt-get update -q
-sudo apt-get install -y clang nasm libstdc++-5-dev\
-                        git bash autoconf flex bison sed


### PR DESCRIPTION
Now that Travis' Bionic support is ex-beta move the deb package
install to the config instead of using apt-get in a script.